### PR TITLE
Fix crash on non-square machines

### DIFF
--- a/compensation/compensation.py
+++ b/compensation/compensation.py
@@ -46,7 +46,7 @@ class Compensation :
 		self.filename = sys.argv[1]
 		self.method = sys.argv[2]
 		
-		#default to cubic if not specified
+		# default to cubic if not specified
 		if self.method == "" : self.methond = "cubic"
 
 
@@ -76,7 +76,7 @@ class Compensation :
 		self.xi,self.yi = np.meshgrid(self.x,self.y)
 		
 		# interpolate, zi has all the offset values
-		self.zi = griddata((self.x_data,self.y_data),self.z_data,(self.yi,self.xi),method=self.method)
+		self.zi = griddata((self.x_data,self.y_data),self.z_data,(self.xi,self.yi),method=self.method)
 		#print self.zi
 
 		
@@ -96,7 +96,7 @@ class Compensation :
 		# get the nearest compensation offset and convert to counts (s32) with a scale (float) 
 		# Requested offset == counts * scale
 		self.scale = 0.001
-		zo = self.zi[self.Xn,self.Yn]
+		zo = self.zi[self.Yn,self.Xn]
 		compensation = int(zo / self.scale)
 		
 		return compensation


### PR DESCRIPTION
The initialization of the griddata is not correct non-square machines and generates an error when the X-axis exceeds the max of the Y-axis. The LOADMAP state prints the following info for my test probe-results file:
```
Compensation entering LOADMAP state
	xMin =  0
	xMax =  400
	yMin =  0
	yMax =  350
	Compensation map loaded
```
and at the moment the X-axis is moved over the yMax value the following error occures.
`IndexError: index 351 is out of bounds for axis 0 with size 351`